### PR TITLE
Fix `top_mem` plugin

### DIFF
--- a/plugins/dool_top_mem.py
+++ b/plugins/dool_top_mem.py
@@ -20,18 +20,18 @@ class dstat_plugin(dstat):
         for pid in proc_pidlist():
             try:
                 ### Using dopen() will cause too many open files
-                l = proc_splitline('/proc/%s/stat' % pid)
+                l = proc_splitline('/proc/%s/statm' % pid)
             except IOError:
                 continue
 
-            if len(l) < 23: continue
-            usage = int(l[23]) * pagesize
+            if len(l) < 2: continue
+            usage = int(l[1]) * pagesize
 
             ### Is it a new topper ?
             if usage <= self.val['max']: continue
 
             self.val['max'] = usage
-            self.val['name'] = getnamebypid(pid, l[1][1:-1])
+            self.val['name'] = getnamebypid(pid, proc_splitline('/proc/%s/comm' % pid)[0:-1])
             self.val['pid'] = pid
 
         self.output = '%-*s%s' % (self.width-5, self.val['name'][0:self.width-5], cprint(self.val['max'], 'f', 5, 1024))


### PR DESCRIPTION
Usage of `proc_splitline()` breaks for processes containing spaces as part of the command name, e.g.
```
2566 (tmux: client) S 2459 2566 2459 34817 2566 4194304 290 14 12 0 0 0 0 0 23 3 1 0 124899 11952128 1010 18446744073709551615 94216560173056 94216560738917 140737080092208 0 0 0 0 3674116 134433283 1 0 0 17 14 0 0 0 0 0 94216560947760 94216561019336 94216574795776 140737080101018 140737080101023 140737080101023 140737080102890 0
```
which ends up taking the value of some other field instead of the RSS.

Given that the command name is only used if it is a new topper, avoid using a regex and use
`/proc/[pid]/statm` instead.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New plugin pull-request
 - Feature pull-request
 - Bugfix pull-request
 - Docs pull-request

##### DSTAT VERSION
```
<!--- Paste verbatim output from “dstat --version” here -->
```

##### SUMMARY
<!--- Describe the change here, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

```
<!--- Paste verbatim command output here, e.g. before and after your change -->
```
