### PR TITLE
Parsing /proc/diskstats: better detection of unused block devices

### DIFF
--- a/dool
+++ b/dool
@@ -825,7 +825,7 @@ class dool_disk(dstat):
         ret = []
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             ret.append(name)
         for item in objlist: ret.append(item)
@@ -882,7 +882,7 @@ class dool_disk(dstat):
             if len(l) < 13: continue
             if l[5] == '0' and l[9] == '0': continue
             name = l[2]
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             if not self.diskfilter.match(name):
                 self.set2['total'] = ( self.set2['total'][0] + int(l[5]), self.set2['total'][1] + int(l[9]) )
             if name in self.vars and name != 'total':
@@ -1248,7 +1248,7 @@ class dool_io(dstat):
         ret = []
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             ret.append(name)
         for item in objlist: ret.append(item)
@@ -1284,7 +1284,7 @@ class dool_io(dstat):
             if len(l) < 13: continue
             if l[3] == '0' and l[7] == '0': continue
             name = l[2]
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             if not self.diskfilter.match(name):
                 self.set2['total'] = ( self.set2['total'][0] + int(l[3]), self.set2['total'][1] + int(l[7]) )
             if name in self.vars and name != 'total':

--- a/plugins/dool_disk_avgqu.py
+++ b/plugins/dool_disk_avgqu.py
@@ -20,7 +20,7 @@ class dstat_plugin(dstat):
         ret = []
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             ret.append(name)
         for item in objlist: ret.append(item)
@@ -51,7 +51,7 @@ class dstat_plugin(dstat):
     def extract(self):
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             if l[3] == '0' and l[7] == '0': continue
             name = l[2]
             if name not in self.vars or name == 'total': continue

--- a/plugins/dool_disk_avgrq.py
+++ b/plugins/dool_disk_avgrq.py
@@ -21,7 +21,7 @@ class dstat_plugin(dstat):
         ret = []
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             ret.append(name)
         for item in objlist: ret.append(item)
@@ -52,7 +52,7 @@ class dstat_plugin(dstat):
     def extract(self):
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             if l[3] == '0' and l[7] == '0': continue
             name = l[2]
             if name not in self.vars or name == 'total': continue

--- a/plugins/dool_disk_svctm.py
+++ b/plugins/dool_disk_svctm.py
@@ -24,7 +24,7 @@ class dstat_plugin(dstat):
         ret = []
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             ret.append(name)
         for item in objlist: ret.append(item)
@@ -55,7 +55,7 @@ class dstat_plugin(dstat):
     def extract(self):
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             if l[3] == '0' and l[7] == '0': continue
             name = l[2]
             if name not in self.vars or name == 'total': continue

--- a/plugins/dool_disk_tps.py
+++ b/plugins/dool_disk_tps.py
@@ -20,7 +20,7 @@ class dstat_plugin(dstat):
         ret = []
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             ret.append(name)
         for item in objlist: ret.append(item)
@@ -55,7 +55,7 @@ class dstat_plugin(dstat):
         for l in self.splitlines():
             if len(l) < 13: continue
             if l[3] == '0' and l[7] == '0': continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             if not self.diskfilter.match(name):
                 self.set2['total'] = ( self.set2['total'][0] + int(l[3]), self.set2['total'][1] + int(l[7]) )

--- a/plugins/dool_disk_util.py
+++ b/plugins/dool_disk_util.py
@@ -23,7 +23,7 @@ class dstat_plugin(dstat):
         ret = []
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             ret.append(name)
         for item in objlist: ret.append(item)
@@ -76,7 +76,7 @@ class dstat_plugin(dstat):
         for l in self.splitlines():
             if len(l) < 13: continue
             if l[5] == '0' and l[9] == '0': continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             if name not in self.vars: continue
             self.set2[name] = dict(

--- a/plugins/dool_disk_wait.py
+++ b/plugins/dool_disk_wait.py
@@ -22,7 +22,7 @@ class dstat_plugin(dstat):
         ret = []
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             ret.append(name)
         for item in objlist: ret.append(item)
@@ -54,7 +54,7 @@ class dstat_plugin(dstat):
         for l in self.splitlines():
             if len(l) < 13: continue
             if l[5] == '0' and l[9] == '0': continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             if name not in self.vars: continue
             self.set2[name] = dict(


### PR DESCRIPTION
The format of /proc/diskstats has changed over the years:
Until kernel 4.17 there were 14 fields (which this code assumed)
Since 4.18 there are 18 fields, since 5.5 there are 20 fields.

Assume unused devices have all fields zero.

Closes #1.
Closes #5.
Closes #7.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New plugin pull-request
 - Feature pull-request
 - Bugfix pull-request
 - Docs pull-request

##### DSTAT VERSION
```
<!--- Paste verbatim output from “dstat --version” here -->
```

##### SUMMARY
<!--- Describe the change here, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

```
<!--- Paste verbatim command output here, e.g. before and after your change -->
```
