### PR TITLE
Allow to unbuffer csv output

### DIFF
--- a/dool
+++ b/dool
@@ -79,6 +79,7 @@ class Options:
         self.update       = True
         self.header       = True
         self.output       = False
+        self.unbuffered   = False
         self.pidfile      = False
         self.profile      = ''
 
@@ -102,11 +103,11 @@ class Options:
         }
 
         try:
-            opts, args = getopt.getopt(args, 'acdfghilmno:prstTvyC:D:I:M:N:S:V',
+            opts, args = getopt.getopt(args, 'acdfghilmno:uprstTvyC:D:I:M:N:S:V',
                 ['all', 'all-plugins', 'bits', 'bw', 'bytes', 'black-on-white', 'color',
                  'defaults', 'debug', 'filesystem', 'float', 'full', 'help', 'integer',
                  'list', 'mods', 'modules', 'more', 'nocolor', 'noheaders', 'noupdate',
-                 'output=', 'pidfile=', 'profile', 'version', 'vmstat'] + allplugins)
+                 'output=', 'unbuffered', 'pidfile=', 'profile', 'version', 'vmstat'] + allplugins)
         except getopt.error as exc:
             print('dool: %s, try dool -h for a list of all the options' % exc)
             sys.exit(1)
@@ -198,6 +199,8 @@ class Options:
                 self.update = False
             elif opt in ['-o', '--output']:
                 self.output = arg
+            elif opt in ['-u', '--unbuffered']:
+                self.unbuffered = True
             elif opt in ['--pidfile']:
                 self.pidfile = arg
             elif opt in ['--profile']:
@@ -336,6 +339,7 @@ Dool options:
   --noheaders              disable repetitive headers
   --noupdate               disable intermediate updates
   --output file            write CSV output to file
+  --unbuffered             do not buffer writes to the output file
   --profile                show profiling statistics when exiting dool
 
 delay is the delay in seconds between each update (default: 1)
@@ -2634,15 +2638,19 @@ def main():
     if op.color == None:
         op.color = gettermcolor()
 
-    ### Prepare CSV output file (unbuffered)
+    ### Prepare CSV output file
+    buffering = -1
+    if op.unbuffered:
+        # enforce line buffering
+        buffering = 1
     if op.output:
         if not os.path.exists(op.output):
-            outputfile = open(op.output, 'w')
+            outputfile = open(op.output, 'w', buffering=buffering)
             outputfile.write('"Dstat %s CSV output"\n' % VERSION)
             header = ('"Author:","Dag Wieers <dag@wieers.com>"','','','','"URL:"','"http://dag.wieers.com/home-made/dstat/"\n')
             outputfile.write(char['sep'].join(header))
         else:
-            outputfile = open(op.output, 'a')
+            outputfile = open(op.output, 'a', buffering=buffering)
             outputfile.write('\n\n')
 
         header = ('"Host:"','"%s"' % hostname,'','','','"User:"','"%s"\n' % user)


### PR DESCRIPTION
Add a flag to the command line: -u, --unbuffered

When set the output file (if any) will disable the default python
buffering and the output will be flushed after every single line (line
buffering mode).

This pach offers the opportunity to
- get a consistent view of the metrics when tailing the csv file
- get the metrics regardless the process termination cause (currently
SIGINT will flush the data but not SIGHUP nor SIGTERM for instance)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New plugin pull-request
 - Feature pull-request
 - Bugfix pull-request
 - Docs pull-request

##### DSTAT VERSION
```
<!--- Paste verbatim output from “dstat --version” here -->
```

##### SUMMARY
<!--- Describe the change here, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

```
<!--- Paste verbatim command output here, e.g. before and after your change -->
```
