### PR TITLE
Skip devices without I/O

### DIFF
--- a/dool
+++ b/dool
@@ -810,7 +810,7 @@ class dool_disk(dstat):
         ret = []
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if l[3:] == ['0',] * (len(l) - 3): continue
             name = l[2]
             ret.append(name)
         for item in objlist: ret.append(item)


### PR DESCRIPTION
Linux 4.18+ has added more fields to the diskstats proc file, so the
original skip condition for devices without I/O didn't apply anymore.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New plugin pull-request
 - Feature pull-request
 - Bugfix pull-request
 - Docs pull-request

##### DSTAT VERSION
```
<!--- Paste verbatim output from “dstat --version” here -->
```

##### SUMMARY
<!--- Describe the change here, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

```
<!--- Paste verbatim command output here, e.g. before and after your change -->
```
