### PR TITLE
Fix `module 'importlib' has no attribute 'machinery'`  error in Pytho…

### DIFF
--- a/dool
+++ b/dool
@@ -2696,8 +2696,8 @@ def main():
             pluginfile = 'dool_' + mod.replace('-', '_')
             try:
                 if pluginfile not in globals():
-                    import importlib
-                    spec = importlib.machinery.PathFinder.find_spec(pluginfile, pluginpath)
+                    from importlib import machinery
+                    spec = machinery.PathFinder.find_spec(pluginfile, pluginpath)
 
                     ### Try loading python plugin
                     if spec is not None:


### PR DESCRIPTION
…n 3.10.2

```
Module dool_top_mem failed to load. (module 'importlib' has no attribute 'machinery')
None of the stats you selected are available.
```
For some reason, lookup of `importlib.machinery` fails in Python 3.10.2 after `import importlib`; using
`from importlib import machinery` instead.

Fixes #20.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New plugin pull-request
 - Feature pull-request
 - Bugfix pull-request
 - Docs pull-request

##### DSTAT VERSION
```
<!--- Paste verbatim output from “dstat --version” here -->
```

##### SUMMARY
<!--- Describe the change here, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

```
<!--- Paste verbatim command output here, e.g. before and after your change -->
```
